### PR TITLE
Fix admin repository id type mismatch

### DIFF
--- a/src/main/java/ru/varino/bybit/repositories/AdminRepository.java
+++ b/src/main/java/ru/varino/bybit/repositories/AdminRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import ru.varino.bybit.entities.AdminEntity;
 import ru.varino.bybit.entities.UserEntity;
 
-public interface AdminRepository extends JpaRepository<AdminEntity, Integer> {
+public interface AdminRepository extends JpaRepository<AdminEntity, Long> {
     boolean existsByUser(UserEntity user);
 }

--- a/src/main/java/ru/varino/bybit/services/AdminService.java
+++ b/src/main/java/ru/varino/bybit/services/AdminService.java
@@ -43,17 +43,15 @@ public class AdminService implements ServiceInterface<AdminEntity> {
 
     @Override
     public void remove(Long id) {
-        int intId = id.intValue();
-        if (!adminRepository.existsById(intId)) {
+        if (!adminRepository.existsById(id)) {
             throw new EntityNotFoundException("Админ с id " + id + " не найден");
         }
-        adminRepository.deleteById(intId);
+        adminRepository.deleteById(id);
     }
 
     @Override
     public AdminEntity get(Long id) {
-        int intId = id.intValue();
-        return adminRepository.findById(intId)
+        return adminRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Админ с id " + id + " не найден"));
     }
 


### PR DESCRIPTION
## Summary
- fix incorrect id type for AdminRepository
- use Long type in AdminService for remove/get methods

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683f5379db20832fbb012cd233a60356